### PR TITLE
feat(common): add Canadian tax calculation utility

### DIFF
--- a/libs/common/src/lib/tax.ts
+++ b/libs/common/src/lib/tax.ts
@@ -1,0 +1,21 @@
+import { calculateCanadianTax, Income } from './tax/canada';
+
+export {
+  calculateCanadianTax,
+  calculateCapitalGain,
+  monthlySalaryToIncome
+} from './tax/canada';
+export type { Income, IncomeType, Trade, CapitalGainResult } from './tax/canada';
+
+/**
+ * Generic tax calculation entry point. Currently only supports Canada (CA).
+ * Throws an error for unsupported countries.
+ */
+export function calculateTax(country: string, incomes: Income[]): number {
+  switch (country.toUpperCase()) {
+    case 'CA':
+      return calculateCanadianTax(incomes);
+    default:
+      throw new Error(`Tax calculation for country ${country} not supported`);
+  }
+}

--- a/libs/common/src/lib/tax/canada.spec.ts
+++ b/libs/common/src/lib/tax/canada.spec.ts
@@ -1,0 +1,57 @@
+import {
+  calculateCanadianTax,
+  calculateCapitalGain,
+  monthlySalaryToIncome,
+  calculateTax,
+  Income,
+  Trade
+} from '../tax';
+
+describe('Canadian tax calculation', () => {
+  it('should apply 50% inclusion for capital gains', () => {
+    const incomes: Income[] = [
+      { country: 'US', type: 'capitalGains', amount: 10000 }
+    ];
+    expect(calculateCanadianTax(incomes)).toBeCloseTo(750);
+  });
+
+  it('should apply progressive tax brackets for interest income', () => {
+    const incomes: Income[] = [
+      { country: 'CA', type: 'interest', amount: 60000 }
+    ];
+    const expected = 55867 * 0.15 + (60000 - 55867) * 0.205;
+    expect(calculateCanadianTax(incomes)).toBeCloseTo(expected);
+  });
+
+  it('should calculate tax via generic entry point', () => {
+    const incomes: Income[] = [
+      { country: 'IN', type: 'dividend', amount: 1000 }
+    ];
+    expect(calculateTax('CA', incomes)).toBeCloseTo(150);
+  });
+
+  it('should compute capital gains and losses from trades', () => {
+    const trades: Trade[] = [
+      { buyPrice: 100, sellPrice: 150, quantity: 10 }, // +500
+      { buyPrice: 200, sellPrice: 180, quantity: 5 } // -100
+    ];
+    const result = calculateCapitalGain(trades);
+    expect(result).toEqual({ gains: 500, losses: -100, net: 400 });
+  });
+
+  it('should include salary and capital gains in tax calculation', () => {
+    const trades: Trade[] = [
+      { buyPrice: 100, sellPrice: 150, quantity: 10 }
+    ];
+    const { net } = calculateCapitalGain(trades); // 500
+    const incomes: Income[] = [
+      monthlySalaryToIncome(5000),
+      { country: 'CA', type: 'capitalGains', amount: net }
+    ];
+    const taxableIncome = 5000 * 12 + 0.5 * net;
+    const expectedTax =
+      55867 * 0.15 +
+      (taxableIncome - 55867) * 0.205; // taxableIncome < second bracket limit
+    expect(calculateCanadianTax(incomes)).toBeCloseTo(expectedTax);
+  });
+});

--- a/libs/common/src/lib/tax/canada.ts
+++ b/libs/common/src/lib/tax/canada.ts
@@ -1,0 +1,98 @@
+import { Big } from 'big.js';
+
+export type IncomeType = 'capitalGains' | 'dividend' | 'interest' | 'salary';
+
+export interface Income {
+  country: string; // Country of origin for the income; currently unused
+  type: IncomeType;
+  amount: number; // Amount in CAD
+}
+
+export interface Trade {
+  buyPrice: number;
+  sellPrice: number;
+  quantity: number;
+}
+
+export interface CapitalGainResult {
+  gains: number; // Sum of positive gains
+  losses: number; // Sum of negative losses
+  net: number; // gains + losses
+}
+
+/**
+ * Calculates realized capital gains and losses from a list of trades.
+ */
+export function calculateCapitalGain(trades: Trade[]): CapitalGainResult {
+  return trades.reduce<CapitalGainResult>(
+    (acc, trade) => {
+      const diff = (trade.sellPrice - trade.buyPrice) * trade.quantity;
+      if (diff >= 0) {
+        acc.gains += diff;
+      } else {
+        acc.losses += diff;
+      }
+      acc.net += diff;
+      return acc;
+    },
+    { gains: 0, losses: 0, net: 0 }
+  );
+}
+
+/**
+ * Helper to convert a monthly salary into an annual income record.
+ */
+export function monthlySalaryToIncome(
+  monthlySalary: number,
+  months = 12
+): Income {
+  return {
+    country: 'CA',
+    type: 'salary',
+    amount: monthlySalary * months
+  };
+}
+
+/**
+ * Calculates federal Canadian tax for a resident based on a list of incomes.
+ * This is a simplified implementation and does not include provincial taxes
+ * or deductions.
+ */
+export function calculateCanadianTax(incomes: Income[]): number {
+  const taxableIncome = incomes.reduce((acc, income) => {
+    switch (income.type) {
+      case 'capitalGains':
+        return acc.plus(Math.max(income.amount, 0) * 0.5); // 50% inclusion rate on net gains
+      default:
+        return acc.plus(income.amount);
+    }
+  }, new Big(0));
+
+  return getCanadianFederalTax(taxableIncome.toNumber());
+}
+
+function getCanadianFederalTax(income: number): number {
+  const brackets = [
+    { limit: 55867, rate: 0.15 },
+    { limit: 111733, rate: 0.205 },
+    { limit: 173205, rate: 0.26 },
+    { limit: 246752, rate: 0.29 },
+    { limit: Infinity, rate: 0.33 }
+  ];
+
+  let tax = 0;
+  let previousLimit = 0;
+
+  for (const bracket of brackets) {
+    const taxable = Math.min(income, bracket.limit) - previousLimit;
+    if (taxable > 0) {
+      tax += taxable * bracket.rate;
+    }
+    previousLimit = bracket.limit;
+    if (income <= bracket.limit) {
+      break;
+    }
+  }
+
+  return tax;
+}


### PR DESCRIPTION
## Summary
- add Canadian federal tax calculator with progressive brackets and capital gains inclusion
- provide generic tax entry point to support future countries
- cover tax calculator with unit tests
- track realized capital gains/losses and convert monthly salary into taxable income

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npx jest libs/common/src/lib/tax/canada.spec.ts --config libs/common/jest.config.ts --runInBand`
- `npx nx lint common` *(fails: terminal crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b83d8e048331a1741c8acbfdd705